### PR TITLE
fix the moe operators dtype to int64

### DIFF
--- a/paddle/fluid/operators/assign_pos_op.cc
+++ b/paddle/fluid/operators/assign_pos_op.cc
@@ -33,8 +33,25 @@ class AssignPosOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
-    auto data_type = OperatorWithKernel::IndicateVarDataType(ctx, "cum_count");
-    return framework::OpKernelType(data_type, ctx.device_context());
+    auto cum_count_dtype =
+        OperatorWithKernel::IndicateVarDataType(ctx, "cum_count");
+    auto eff_gates_len_dtype =
+        OperatorWithKernel::IndicateVarDataType(ctx, "eff_gates_len");
+    auto X_dtype = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+    PADDLE_ENFORCE_EQ(
+        cum_count_dtype == eff_gates_len_dtype, 1,
+        platform::errors::InvalidArgument(
+            "The dtype of the cum_count and eff_gates_len should be same"));
+    PADDLE_ENFORCE_EQ(cum_count_dtype == X_dtype, 1,
+                      platform::errors::InvalidArgument(
+                          "The dtype of the cum_count and X should be same"));
+    // auto expert_count_data_dtype =
+    // static_cast<framework::proto::VarType::Type>(expert_count_dtype);
+    PADDLE_ENFORCE_EQ(cum_count_dtype == framework::proto::VarType::INT64, 1,
+                      platform::errors::InvalidArgument(
+                          "The dtype of the cum_count_dtype, eff_gates_len and "
+                          "X should be same as int64"));
+    return framework::OpKernelType(cum_count_dtype, ctx.device_context());
   }
 };
 

--- a/paddle/fluid/operators/assign_pos_op.cc
+++ b/paddle/fluid/operators/assign_pos_op.cc
@@ -35,19 +35,12 @@ class AssignPosOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext& ctx) const override {
     auto cum_count_dtype =
         OperatorWithKernel::IndicateVarDataType(ctx, "cum_count");
-    auto eff_gates_len_dtype =
-        OperatorWithKernel::IndicateVarDataType(ctx, "eff_gates_len");
     auto X_dtype = OperatorWithKernel::IndicateVarDataType(ctx, "X");
-    PADDLE_ENFORCE_EQ(
-        cum_count_dtype == eff_gates_len_dtype, 1,
-        platform::errors::InvalidArgument(
-            "The dtype of the cum_count and eff_gates_len should be same"));
-    PADDLE_ENFORCE_EQ(cum_count_dtype == X_dtype, 1,
+
+    PADDLE_ENFORCE_EQ(cum_count_dtype, X_dtype,
                       platform::errors::InvalidArgument(
                           "The dtype of the cum_count and X should be same"));
-    // auto expert_count_data_dtype =
-    // static_cast<framework::proto::VarType::Type>(expert_count_dtype);
-    PADDLE_ENFORCE_EQ(cum_count_dtype == framework::proto::VarType::INT64, 1,
+    PADDLE_ENFORCE_EQ(cum_count_dtype, framework::proto::VarType::INT64,
                       platform::errors::InvalidArgument(
                           "The dtype of the cum_count_dtype, eff_gates_len and "
                           "X should be same as int64"));

--- a/paddle/fluid/operators/assign_pos_op.cu
+++ b/paddle/fluid/operators/assign_pos_op.cu
@@ -88,5 +88,4 @@ class AssignPosCUDAKernel : public framework::OpKernel<T> {
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
-REGISTER_OP_CUDA_KERNEL(assign_pos, ops::AssignPosCUDAKernel<int>,
-                        ops::AssignPosCUDAKernel<int64_t>);
+REGISTER_OP_CUDA_KERNEL(assign_pos, ops::AssignPosCUDAKernel<int64_t>);

--- a/paddle/fluid/operators/expert_count_op.cc
+++ b/paddle/fluid/operators/expert_count_op.cc
@@ -27,6 +27,21 @@ class ExpertCountOp : public framework::OperatorWithKernel {
     OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "expert_count",
                    "ExpertCount");
   }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    // the dtype of the gate_idx should be same as int64
+    auto gate_idx_dtype =
+        OperatorWithKernel::IndicateVarDataType(ctx, "gate_idx");
+    // auto gate_idx_data_dtype =
+    // static_cast<framework::proto::VarType::Type>(gate_idx_dtype);
+    PADDLE_ENFORCE_EQ(
+        gate_idx_dtype == framework::proto::VarType::INT64, 1,
+        platform::errors::InvalidArgument(
+            "The dtype of the gate_idx_dtype should be same as int64"));
+    return framework::OpKernelType(gate_idx_dtype, ctx.GetPlace());
+  }
 };
 
 class ExpertCountOpMaker : public framework::OpProtoAndCheckerMaker {

--- a/paddle/fluid/operators/expert_count_op.cc
+++ b/paddle/fluid/operators/expert_count_op.cc
@@ -34,12 +34,10 @@ class ExpertCountOp : public framework::OperatorWithKernel {
     // the dtype of the gate_idx should be same as int64
     auto gate_idx_dtype =
         OperatorWithKernel::IndicateVarDataType(ctx, "gate_idx");
-    // auto gate_idx_data_dtype =
-    // static_cast<framework::proto::VarType::Type>(gate_idx_dtype);
-    PADDLE_ENFORCE_EQ(
-        gate_idx_dtype == framework::proto::VarType::INT64, 1,
-        platform::errors::InvalidArgument(
-            "The dtype of the gate_idx_dtype should be same as int64"));
+
+    PADDLE_ENFORCE_EQ(gate_idx_dtype, framework::proto::VarType::INT64,
+                      platform::errors::InvalidArgument(
+                          "The dtype of the gate_idx_dtype should be int64"));
     return framework::OpKernelType(gate_idx_dtype, ctx.GetPlace());
   }
 };

--- a/paddle/fluid/operators/expert_count_op.cu
+++ b/paddle/fluid/operators/expert_count_op.cu
@@ -101,5 +101,4 @@ class ExpertCountOpCUDAKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
 
-REGISTER_OP_CUDA_KERNEL(expert_count, ops::ExpertCountOpCUDAKernel<int>,
-                        ops::ExpertCountOpCUDAKernel<int64_t>);
+REGISTER_OP_CUDA_KERNEL(expert_count, ops::ExpertCountOpCUDAKernel<int64_t>);

--- a/paddle/fluid/operators/index_select_op.cu
+++ b/paddle/fluid/operators/index_select_op.cu
@@ -197,15 +197,21 @@ class IndexSelectGradCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
+namespace plf = paddle::platform;
+
 REGISTER_OP_CUDA_KERNEL(
     index_select,
     ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext,
+                               plf::float16>,
     ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext, double>,
     ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext, int>,
     ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext, int64_t>);
 REGISTER_OP_CUDA_KERNEL(
     index_select_grad,
     ops::IndexSelectGradCUDAKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::IndexSelectCUDAKernel<paddle::platform::CUDADeviceContext,
+                               plf::float16>,
     ops::IndexSelectGradCUDAKernel<paddle::platform::CUDADeviceContext, double>,
     ops::IndexSelectGradCUDAKernel<paddle::platform::CUDADeviceContext, int>,
     ops::IndexSelectGradCUDAKernel<paddle::platform::CUDADeviceContext,

--- a/paddle/fluid/operators/limit_by_capacity_op.cc
+++ b/paddle/fluid/operators/limit_by_capacity_op.cc
@@ -31,6 +31,28 @@ class LimitByCapacityOp : public framework::OperatorWithKernel {
     ctx->ShareDim("expert_count", "Out");
     ctx->ShareLoD("expert_count", "Out");
   }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    // the dtype of the expert_count and capacity should be same as int64
+    auto expert_count_dtype =
+        OperatorWithKernel::IndicateVarDataType(ctx, "expert_count");
+    auto capacity_dtype =
+        OperatorWithKernel::IndicateVarDataType(ctx, "capacity");
+
+    PADDLE_ENFORCE_EQ(
+        expert_count_dtype == capacity_dtype, 1,
+        platform::errors::InvalidArgument(
+            "The dtype of the expert_count and capacity should be same"));
+    // auto expert_count_data_dtype =
+    // static_cast<framework::proto::VarType::Type>(expert_count_dtype);
+    PADDLE_ENFORCE_EQ(
+        expert_count_dtype == framework::proto::VarType::INT64, 1,
+        platform::errors::InvalidArgument("The dtype of the expert_count and "
+                                          "capacity should be same as int64"));
+    return framework::OpKernelType(expert_count_dtype, ctx.GetPlace());
+  }
 };
 
 class LimitByCapacityOpMaker : public framework::OpProtoAndCheckerMaker {

--- a/paddle/fluid/operators/limit_by_capacity_op.cc
+++ b/paddle/fluid/operators/limit_by_capacity_op.cc
@@ -42,13 +42,12 @@ class LimitByCapacityOp : public framework::OperatorWithKernel {
         OperatorWithKernel::IndicateVarDataType(ctx, "capacity");
 
     PADDLE_ENFORCE_EQ(
-        expert_count_dtype == capacity_dtype, 1,
+        expert_count_dtype, capacity_dtype,
         platform::errors::InvalidArgument(
             "The dtype of the expert_count and capacity should be same"));
-    // auto expert_count_data_dtype =
-    // static_cast<framework::proto::VarType::Type>(expert_count_dtype);
+
     PADDLE_ENFORCE_EQ(
-        expert_count_dtype == framework::proto::VarType::INT64, 1,
+        expert_count_dtype, framework::proto::VarType::INT64,
         platform::errors::InvalidArgument("The dtype of the expert_count and "
                                           "capacity should be same as int64"));
     return framework::OpKernelType(expert_count_dtype, ctx.GetPlace());

--- a/paddle/fluid/operators/prune_gate_by_capacity_op.cc
+++ b/paddle/fluid/operators/prune_gate_by_capacity_op.cc
@@ -60,8 +60,19 @@ class PruneGateByCapacityOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
-    auto data_type = OperatorWithKernel::IndicateVarDataType(ctx, "GateIdx");
-    return framework::OpKernelType(data_type, ctx.device_context());
+    auto gate_idx_data_type =
+        OperatorWithKernel::IndicateVarDataType(ctx, "GateIdx");
+    auto expert_count_data_type =
+        OperatorWithKernel::IndicateVarDataType(ctx, "ExpertCount");
+    PADDLE_ENFORCE_EQ(
+        gate_idx_data_type == expert_count_data_type, 1,
+        platform::errors::InvalidArgument(
+            "The dtype of the gate_idx and expert_count should be same"));
+    PADDLE_ENFORCE_EQ(gate_idx_data_type == framework::proto::VarType::INT64, 1,
+                      platform::errors::InvalidArgument(
+                          "The dtype of the gate_idx and expert_count should "
+                          "be same as int64"));
+    return framework::OpKernelType(gate_idx_data_type, ctx.device_context());
   }
 };
 

--- a/paddle/fluid/operators/prune_gate_by_capacity_op.cc
+++ b/paddle/fluid/operators/prune_gate_by_capacity_op.cc
@@ -65,10 +65,10 @@ class PruneGateByCapacityOp : public framework::OperatorWithKernel {
     auto expert_count_data_type =
         OperatorWithKernel::IndicateVarDataType(ctx, "ExpertCount");
     PADDLE_ENFORCE_EQ(
-        gate_idx_data_type == expert_count_data_type, 1,
+        gate_idx_data_type, expert_count_data_type,
         platform::errors::InvalidArgument(
             "The dtype of the gate_idx and expert_count should be same"));
-    PADDLE_ENFORCE_EQ(gate_idx_data_type == framework::proto::VarType::INT64, 1,
+    PADDLE_ENFORCE_EQ(gate_idx_data_type, framework::proto::VarType::INT64,
                       platform::errors::InvalidArgument(
                           "The dtype of the gate_idx and expert_count should "
                           "be same as int64"));

--- a/paddle/fluid/operators/prune_gate_by_capacity_op.cu
+++ b/paddle/fluid/operators/prune_gate_by_capacity_op.cu
@@ -86,14 +86,12 @@ class PruneGateByCapacityFunctor {
 template <typename Visitor>
 static void VisitDataType(framework::proto::VarType::Type type,
                           Visitor visitor) {
-  if (type == framework::proto::VarType::INT32) {
-    visitor.template apply<int>();
-  } else if (type == framework::proto::VarType::INT64) {
+  if (type == framework::proto::VarType::INT64) {
     visitor.template apply<int64_t>();
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "The recieved values gate_id type %s can not meet input requirements. "
-        "Because the given gate_id data type of operators must be int32 or "
+        "Because the given gate_id data type of operators must be "
         "int64. Please input appropriate gate_id again! ",
         framework::DataTypeToString(type)));
   }
@@ -121,5 +119,4 @@ class PruneGateByCapacityCUDAKernel : public framework::OpKernel<T> {
 
 REGISTER_OP_CUDA_KERNEL(
     prune_gate_by_capacity,
-    ops::PruneGateByCapacityCUDAKernel<plat::CUDADeviceContext, int>,
     ops::PruneGateByCapacityCUDAKernel<plat::CUDADeviceContext, int64_t>);


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix the moe operators dtype to int64.